### PR TITLE
Add tests and refactor as necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ build
 .project
 /bin/
 /.settings/
+
+
+# Ignore IntelliJ IDEA project files
+.idea

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ plugins {
     id "com.jfrog.bintray" version "1.8.4"
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.11
+targetCompatibility = 1.11
 
 group = 'com.kori_47'
 version = '0.1.0'

--- a/src/main/java/com/kori_47/sudoku/AbstractCellGroup.java
+++ b/src/main/java/com/kori_47/sudoku/AbstractCellGroup.java
@@ -132,6 +132,7 @@ abstract class AbstractCellGroup<V> implements CellGroup<V> {
 		// return a new LinkedHashMap containing cells.
 		return cells.values().stream()
 				.sorted()
+				.limit(size) // truncate any extra Cells given
 				.collect(toMap(cell -> cell.id(), cell -> cell,
 						(oldValue, newValue) -> newValue,
 						() -> new LinkedHashMap<String, Cell<V>>(cells.size())));

--- a/src/main/java/com/kori_47/sudoku/Cell.java
+++ b/src/main/java/com/kori_47/sudoku/Cell.java
@@ -16,8 +16,8 @@ import java.util.Set;
  * of the {@link LatinSquare} <strong><i>L</i></strong> and the y coordinate of a {@code Cell} is the
  * <strong><i>j<sup>th</sup></i></strong>{@code Row} of the {@code LatinSquare} <strong><i>L</i></strong> such that:
  * <pre>
- * 				x = i and 0 <= i < s
- * 		and		y = j and 0 <= j < s
+ * 				x = i and 0 &le; i &lt; s
+ * 		and		y = j and 0 &le; j &lt; s
  * 		where	s is the size of L
  * </pre>
  * 

--- a/src/main/java/com/kori_47/sudoku/CellFactory.java
+++ b/src/main/java/com/kori_47/sudoku/CellFactory.java
@@ -7,7 +7,7 @@ package com.kori_47.sudoku;
  * An object that creates new {@link Cell}s. Using cell factories avoids hardwiring and
  * enables clients to use special {@code Cell} subclasses.
  * 
- * <p>This is a functional interface whose functional method is {@link #createCell(int, int, Symbol)}.
+ * <p>This is a functional interface whose functional method is {@link #createCell(String, int, int, Symbol)}.
  * 
  * @param <V> the type of value held by the {@link Symbol}s supported by the {@code Cell}s created
  * using this {@code CellFactory}.

--- a/src/main/java/com/kori_47/sudoku/Cells.java
+++ b/src/main/java/com/kori_47/sudoku/Cells.java
@@ -210,9 +210,9 @@ public final class Cells {
 	 * to {@link Cell#equals(Object)} method, two {@code Cell}s are equal if the following of their
 	 * properties are equal:
 	 * <ul>
-	 * <li>The <i>{@link #id() ids}</i> of the {@code Cell}s</li>
-	 * <li>The <i>{@link #x() x coordinates}</i> of the {@code Cell}s.</li>
-	 * <li>The <i>{@link #y() y coordinates}</i> of the {@code Cell}s.</li>
+	 * <li>The <i>{@link Cell#id() ids}</i> of the {@code Cell}s</li>
+	 * <li>The <i>{@link Cell#x() x coordinates}</i> of the {@code Cell}s.</li>
+	 * <li>The <i>{@link Cell#y() y coordinates}</i> of the {@code Cell}s.</li>
 	 * </ul>
 	 *
 	 * <p>
@@ -234,6 +234,37 @@ public final class Cells {
 		if (!(obj instanceof Cell)) return false;
 		Cell<?> _obj =  (Cell<?>)obj;
 		return cell.x() == _obj.x() && cell.y() == _obj.y() && cell.id().equals(_obj.id());
+	}
+	
+	/**
+	 * Compares the given {@link Cell} and {@code Object} for equality. Returns {@code true} if
+	 * the given object is also a {@code Cell} and the two {@code Cell}s are identical. In addition
+	 * to comparing the two {@code Cell}s for equality using the properties specified in the
+	 * {@link Cell#equals(Object) equals(Object)} method of the {@code Cell} interface, this method
+	 * also uses the {@link Symbol} of the {@code Cell} in the comparison. That is, according to this
+	 * method, two {@code Cell}s are equal if the following of their properties are equal:
+	 * <ul>
+	 * <li>The <i>{@link Cell#id() ids}</i> of the {@code Cell}s</li>
+	 * <li>The <i>{@link Cell#x() x coordinates}</i> of the {@code Cell}s.</li>
+	 * <li>The <i>{@link Cell#y() y coordinates}</i> of the {@code Cell}s.</li>
+	 * <li>The <i>{@link Cell#symbol() symbols}</i> of the {@code Cell}s.</li>
+	 * </ul>
+	 * 
+	 * @param cell the {@code Cell} to compare to the given object for equality. Must <b>NOT</b> be {@code null}.
+	 * @param obj the object to compare for equality with the given {@code Cell}. Maybe {@code null}.
+	 * 
+	 * @return {@code true} if the given {@code Cell} is equal to the given object, {@code false} otherwise.
+	 * 
+	 * @throws NullPointerException if {@code cell} is {@code null}.
+	 * 
+	 * @see Cell#deepEquals(Object)
+	 * @see Cell#equals(Object)
+	 */
+	public static final boolean deepEquals(Cell<?> cell, Object obj) {
+		if (!Cells.equals(cell, obj)) return false;
+		Cell<?> _obj =  (Cell<?>) obj;
+		return ((!cell.symbol().isPresent()))? _obj.symbol().orElse(null) == null :
+				cell.symbol().get().equals(_obj.symbol().orElse(null));
 	}
 	
 	/**
@@ -274,9 +305,9 @@ public final class Cells {
 	}
 	
 	/**
-	 * This method swaps the properties of the two given {@link Cell}s such that after this method returns, {@code cell1} will
-	 * have the properties of {@code cell2} before the call and {@code cell2} will have the properties of {@code cell1} before
-	 * the call.
+	 * This method swaps the {@link Symbol}s of the two given {@link Cell}s such that after this method returns, {@code cell1}
+	 * will have the {@code Symbol} of {@code cell2} before the call and {@code cell2} will have the {@code Symbol} of {@code cell1}
+	 * before the call.
 	 * 
 	 * @param <V> the type of value held by the {@link Symbol}s supported by the {@code Cell}s being swapped .
 	 * 
@@ -288,10 +319,10 @@ public final class Cells {
 	 * 
 	 * @apiNote
 	 * This method is mostly useful to {@link LatinSquare} implementations when performing flip operations making it easy to swap
-	 * {@code Cell} properties without the need to create new temporary {@code LatinSquare}'s to hold the values of the
+	 * {@code Cell} {@code Symbol}s without the need to create new temporary {@code LatinSquare}'s to hold the values of the
 	 * {@code LatinSquare} in question during the flip.
 	 */
-	public static final <V> void swapCellProperties(Cell<V> cell1, Cell<V> cell2) {
+	public static final <V> void swapCellSymbols(Cell<V> cell1, Cell<V> cell2) {
 		requireNonNull(cell1, "cell1 cannot be null.");
 		requireNonNull(cell2, "cell2 cannot be null.");
 		
@@ -301,7 +332,7 @@ public final class Cells {
 
 		// clear the cells
 		cell1.clear();
-		cell2.clear();;
+		cell2.clear();
 		
 		// set the Cell's values
 		cell1.changeSymbol(symbol2);

--- a/src/main/java/com/kori_47/sudoku/Formattables.java
+++ b/src/main/java/com/kori_47/sudoku/Formattables.java
@@ -62,7 +62,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code cell} is {@code null}.
 	 */
-	public static final String toXY(final Cell<?> cell) {
+	public static String toXY(final Cell<?> cell) {
 		return toXY(cell, DEFAULT_SEPARATOR);
 	}
 
@@ -80,7 +80,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXY(final Cell<?> cell, final String separator) {
+	public static String toXY(final Cell<?> cell, final String separator) {
 		requireNonNull(cell, "cell cannot be null.");
 		requireNonNull(separator, "separator cannot be null.");
 		return cell.x() + separator + cell.y();
@@ -104,7 +104,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code cellGroup} is {@code null}.
 	 */
-	public static final String toXY(final CellGroup<?> cellGroup) {
+	public static String toXY(final CellGroup<?> cellGroup) {
 		return toXY(cellGroup, DEFAULT_DELIMITER);
 	}
 
@@ -124,14 +124,15 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXY(final CellGroup<?> cellGroup, final String delimiter) {
+	public static String toXY(final CellGroup<?> cellGroup, final String delimiter) {
 		requireNonNull(cellGroup, "cellGroup cannot be null.");
 		requireNonNull(delimiter, "delimiter cannot be null.");
 		return cellGroup.cells().values().stream().sorted().collect(of(
 				() -> new StringJoiner(delimiter),
 				(joiner, cell) -> joiner.add(cell.toXY()),
-				(joiner1, joiner2) -> joiner1.merge(joiner2), 
-				StringJoiner::toString ));
+                StringJoiner::merge,
+				StringJoiner::toString
+		));
 	}
 
 	/**
@@ -152,7 +153,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code latinSquare} is {@code null}.
 	 */
-	public static final String toXY(final LatinSquare<?> latinSquare) {
+	public static String toXY(final LatinSquare<?> latinSquare) {
 		return toXY(latinSquare, DEFAULT_DELIMITER);
 	}
 	
@@ -172,14 +173,15 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXY(final LatinSquare<?> latinSquare, final String delimiter) {
+	public static String toXY(final LatinSquare<?> latinSquare, final String delimiter) {
 		requireNonNull(latinSquare, "latinSquare cannot be null.");
 		requireNonNull(delimiter, "delimiter cannot be null.");
 		return latinSquare.rows().values().stream().sorted(REVERSE_ROW_COMPARATOR).collect(of(
 				() -> new StringJoiner(delimiter),
 				(joiner, row) -> joiner.add(row.toXY()),
-				(joiner1, joiner2) -> joiner1.merge(joiner2), 
-				StringJoiner::toString ));
+                StringJoiner::merge,
+				StringJoiner::toString
+		));
 	}
 
 	/* ============================================================================
@@ -201,7 +203,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code Cell} is {@code null}.
 	 */
-	public static final String toXYV(final Cell<?> cell) {
+	public static String toXYV(final Cell<?> cell) {
 		return toXYV(cell, DEFAULT_SEPARATOR);
 	}
 
@@ -222,7 +224,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYV(final Cell<?> cell, final String separator) {
+	public static String toXYV(final Cell<?> cell, final String separator) {
 		return toXYV(cell, separator, DEFAULT_PLACEHOLDER);
 	}
 	
@@ -241,7 +243,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYV(final Cell<?> cell, final String separator, final String placeholder) {
+	public static String toXYV(final Cell<?> cell, final String separator, final String placeholder) {
 		requireNonNull(cell, "cell cannot be null.");
 		requireNonNull(separator, "separator cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
@@ -268,7 +270,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code cellGroup} is {@code null}.
 	 */
-	public static final String toXYV(final CellGroup<?> cellGroup) {
+	public static String toXYV(final CellGroup<?> cellGroup) {
 		return toXYV(cellGroup, DEFAULT_DELIMITER);
 	}
 
@@ -292,7 +294,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYV(final CellGroup<?> cellGroup, final String delimiter) {
+	public static String toXYV(final CellGroup<?> cellGroup, final String delimiter) {
 		return toXYV(cellGroup, delimiter, DEFAULT_PLACEHOLDER);
 	}
 	
@@ -314,15 +316,16 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYV(final CellGroup<?> cellGroup, final String delimiter, final String placeholder) {
+	public static String toXYV(final CellGroup<?> cellGroup, final String delimiter, final String placeholder) {
 		requireNonNull(cellGroup, "cellGroup cannot be null.");
 		requireNonNull(delimiter, "delimiter cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
 		return cellGroup.cells().values().stream().sorted().collect(of(
 				() -> new StringJoiner(delimiter),
 				(joiner, cell) -> joiner.add(cell.toXYV()),
-				(joiner1, joiner2) -> joiner1.merge(joiner2), 
-				StringJoiner::toString ));
+                StringJoiner::merge,
+				StringJoiner::toString
+		));
 	}
 	
 	/**
@@ -344,7 +347,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code latinSquare} is {@code null}.
 	 */
-	public static final String toXYV(final LatinSquare<?> latinSquare) {
+	public static String toXYV(final LatinSquare<?> latinSquare) {
 		return toXYV(latinSquare, DEFAULT_DELIMITER);
 	}
 
@@ -368,7 +371,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYV(final LatinSquare<?> latinSquare, final String delimiter) {
+	public static String toXYV(final LatinSquare<?> latinSquare, final String delimiter) {
 		return toXYV(latinSquare, delimiter, DEFAULT_PLACEHOLDER);
 	}
 	
@@ -390,15 +393,16 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYV(final LatinSquare<?> latinSquare, final String delimiter, final String placeholder) {
+	public static String toXYV(final LatinSquare<?> latinSquare, final String delimiter, final String placeholder) {
 		requireNonNull(latinSquare, "latinSquare cannot be null.");
 		requireNonNull(delimiter, "delimiter cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
 		return latinSquare.rows().values().stream().sorted(REVERSE_ROW_COMPARATOR).collect(of(
 				() -> new StringJoiner(delimiter),
 				(joiner, row) -> joiner.add(row.toXYV()),
-				(joiner1, joiner2) -> joiner1.merge(joiner2), 
-				StringJoiner::toString ));
+                StringJoiner::merge,
+				StringJoiner::toString
+		));
 	}
 	/* ============================================================================
 	 * toXYI()
@@ -423,7 +427,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code cell} is {@code null}.
 	 */
-	public static final String toXYI(final Cell<?> cell) {
+	public static String toXYI(final Cell<?> cell) {
 		return toXYI(cell, DEFAULT_SEPARATOR);
 	}
 
@@ -447,7 +451,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYI(final Cell<?> cell, final String separator) {
+	public static String toXYI(final Cell<?> cell, final String separator) {
 		return toXYI(cell, separator, DEFAULT_PLACEHOLDER);
 	}
 
@@ -468,7 +472,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYI(final Cell<?> cell, final String separator, final String placeholder) {
+	public static String toXYI(final Cell<?> cell, final String separator, final String placeholder) {
 		requireNonNull(cell, "cell cannot be null.");
 		requireNonNull(separator, "separator cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
@@ -494,7 +498,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code cellGroup} is {@code null}.
 	 */
-	public static final String toXYI(final CellGroup<?> cellGroup) {
+	public static String toXYI(final CellGroup<?> cellGroup) {
 		return toXYI(cellGroup, DEFAULT_DELIMITER);
 	}
 
@@ -517,7 +521,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYI(final CellGroup<?> cellGroup, final String delimiter) {
+	public static String toXYI(final CellGroup<?> cellGroup, final String delimiter) {
 		return toXYI(cellGroup, delimiter, DEFAULT_PLACEHOLDER);
 	}
 	
@@ -538,15 +542,16 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYI(final CellGroup<?> cellGroup, final String delimiter, final String placeholder) {
+	public static String toXYI(final CellGroup<?> cellGroup, final String delimiter, final String placeholder) {
 		requireNonNull(cellGroup, "cellGroup cannot be null.");
 		requireNonNull(delimiter, "delimiter cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
 		return cellGroup.cells().values().stream().sorted().collect(of(
 				() -> new StringJoiner(delimiter),
 				(joiner, cell) -> joiner.add(cell.toXYI()),
-				(joiner1, joiner2) -> joiner1.merge(joiner2), 
-				StringJoiner::toString ));
+                StringJoiner::merge,
+				StringJoiner::toString
+		));
 	}
 	
 	/**
@@ -567,7 +572,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code latinSquare} is {@code null}.
 	 */
-	public static final String toXYI(final LatinSquare<?> latinSquare) {
+	public static String toXYI(final LatinSquare<?> latinSquare) {
 		return toXYI(latinSquare, DEFAULT_DELIMITER);
 	}
 
@@ -590,7 +595,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYI(final LatinSquare<?> latinSquare, final String delimiter) {
+	public static String toXYI(final LatinSquare<?> latinSquare, final String delimiter) {
 		return toXYI(latinSquare, delimiter, DEFAULT_PLACEHOLDER);
 	}
 	
@@ -611,15 +616,16 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toXYI(final LatinSquare<?> latinSquare, final String delimiter, final String placeholder) {
+	public static String toXYI(final LatinSquare<?> latinSquare, final String delimiter, final String placeholder) {
 		requireNonNull(latinSquare, "latinSquare cannot be null.");
 		requireNonNull(delimiter, "delimiter cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
 		return latinSquare.rows().values().stream().sorted(REVERSE_ROW_COMPARATOR).collect(of(
 				() -> new StringJoiner(delimiter),
 				(joiner, row) -> joiner.add(row.toXYI()),
-				(joiner1, joiner2) -> joiner1.merge(joiner2), 
-				StringJoiner::toString ));
+                StringJoiner::merge,
+				StringJoiner::toString
+		));
 	}
 	/* ============================================================================
 	 * toV()
@@ -642,7 +648,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code cell} is {@code null}.
 	 */
-	public static final String toV(final Cell<?> cell) {
+	public static String toV(final Cell<?> cell) {
 		return toV(cell, DEFAULT_PLACEHOLDER);
 	}
 
@@ -661,7 +667,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toV(final Cell<?> cell, final String placeholder) {
+	public static String toV(final Cell<?> cell, final String placeholder) {
 		requireNonNull(cell, "cell cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
 		return cell.symbol().isPresent()? cell.symbol().get().value().toString() : placeholder;
@@ -685,7 +691,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code cellGroup} is {@code null}.
 	 */
-	public static final String toV(final CellGroup<?> cellGroup) {
+	public static String toV(final CellGroup<?> cellGroup) {
 		return toV(cellGroup, DEFAULT_DELIMITER);
 	}
 
@@ -708,7 +714,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toV(final CellGroup<?> cellGroup, final String delimiter) {
+	public static String toV(final CellGroup<?> cellGroup, final String delimiter) {
 		return toV(cellGroup, delimiter, DEFAULT_PLACEHOLDER);
 	}
 
@@ -729,15 +735,16 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toV(final CellGroup<?> cellGroup, final String delimiter, final String placeholder) {
+	public static String toV(final CellGroup<?> cellGroup, final String delimiter, final String placeholder) {
 		requireNonNull(cellGroup, "cellGroup cannot be null.");
 		requireNonNull(delimiter, "delimiter cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
 		return cellGroup.cells().values().stream().sorted().collect(of(
 				() -> new StringJoiner(delimiter),
 				(joiner, cell) -> joiner.add(cell.toV()),
-				(joiner1, joiner2) -> joiner1.merge(joiner2), 
-				StringJoiner::toString ));
+                StringJoiner::merge,
+				StringJoiner::toString
+		));
 	}
 
 	/**
@@ -758,7 +765,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code latinSquare} is {@code null}.
 	 */
-	public static final String toV(final LatinSquare<?> latinSquare) {
+	public static String toV(final LatinSquare<?> latinSquare) {
 		return toV(latinSquare, DEFAULT_DELIMITER);
 	}
 
@@ -781,7 +788,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toV(final LatinSquare<?> latinSquare, final String delimiter) {
+	public static String toV(final LatinSquare<?> latinSquare, final String delimiter) {
 		return toV(latinSquare, delimiter, DEFAULT_PLACEHOLDER);
 	}
 
@@ -802,15 +809,16 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toV(final LatinSquare<?> latinSquare, final String delimiter, final String placeholder) {
+	public static String toV(final LatinSquare<?> latinSquare, final String delimiter, final String placeholder) {
 		requireNonNull(latinSquare, "latinSquare cannot be null.");
 		requireNonNull(delimiter, "delimiter cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
 		return latinSquare.rows().values().stream().sorted(REVERSE_ROW_COMPARATOR).collect(of(
 				() -> new StringJoiner(delimiter),
 				(joiner, row) -> joiner.add(row.toV()),
-				(joiner1, joiner2) -> joiner1.merge(joiner2), 
-				StringJoiner::toString ));
+                StringJoiner::merge,
+				StringJoiner::toString
+		));
 	}
 	/* ============================================================================
 	 * toI()
@@ -833,7 +841,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code cell} is {@code null}.
 	 */
-	public static final String toI(final Cell<?> cell) {
+	public static String toI(final Cell<?> cell) {
 		return toV(cell, DEFAULT_PLACEHOLDER);
 	}
 
@@ -852,7 +860,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toI(final Cell<?> cell, final String placeholder) {
+	public static String toI(final Cell<?> cell, final String placeholder) {
 		requireNonNull(cell, "cell cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
 		return cell.symbol().isPresent()? Integer.toString(cell.symbol().get().id()) : placeholder;
@@ -876,7 +884,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code cellGroup} is {@code null}.
 	 */
-	public static final String toI(final CellGroup<?> cellGroup) {
+	public static String toI(final CellGroup<?> cellGroup) {
 		return toI(cellGroup, DEFAULT_DELIMITER);
 	}
 
@@ -899,7 +907,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toI(final CellGroup<?> cellGroup, final String delimiter) {
+	public static String toI(final CellGroup<?> cellGroup, final String delimiter) {
 		return toI(cellGroup, delimiter, DEFAULT_PLACEHOLDER);
 	}
 
@@ -920,15 +928,16 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toI(final CellGroup<?> cellGroup, final String delimiter, final String placeholder) {
+	public static String toI(final CellGroup<?> cellGroup, final String delimiter, final String placeholder) {
 		requireNonNull(cellGroup, "cellGroup cannot be null.");
 		requireNonNull(delimiter, "delimiter cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
 		return cellGroup.cells().values().stream().sorted().collect(of(
 				() -> new StringJoiner(delimiter),
 				(joiner, cell) -> joiner.add(cell.toI()),
-				(joiner1, joiner2) -> joiner1.merge(joiner2), 
-				StringJoiner::toString ));
+                StringJoiner::merge,
+				StringJoiner::toString
+		));
 	}
 
 	/**
@@ -949,7 +958,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if {@code latinSquare} is {@code null}.
 	 */
-	public static final String toI(final LatinSquare<?> latinSquare) {
+	public static String toI(final LatinSquare<?> latinSquare) {
 		return toV(latinSquare, DEFAULT_DELIMITER);
 	}
 
@@ -972,7 +981,7 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toI(final LatinSquare<?> latinSquare, final String delimiter) {
+	public static String toI(final LatinSquare<?> latinSquare, final String delimiter) {
 		return toV(latinSquare, delimiter, DEFAULT_PLACEHOLDER);
 	}
 
@@ -993,15 +1002,16 @@ public final class Formattables {
 	 * 
 	 * @throws NullPointerException if any of the arguments to this method is/are {@code null}.
 	 */
-	public static final String toI(final LatinSquare<?> latinSquare, final String delimiter, final String placeholder) {
+	public static String toI(final LatinSquare<?> latinSquare, final String delimiter, final String placeholder) {
 		requireNonNull(latinSquare, "latinSquare cannot be null.");
 		requireNonNull(delimiter, "delimiter cannot be null.");
 		requireNonNull(placeholder, "placeholder cannot be null.");
 		return latinSquare.rows().values().stream().sorted(REVERSE_ROW_COMPARATOR).collect(of(
 				() -> new StringJoiner(delimiter),
 				(joiner, row) -> joiner.add(row.toI()),
-				(joiner1, joiner2) -> joiner1.merge(joiner2), 
-				StringJoiner::toString ));
+                StringJoiner::merge,
+				StringJoiner::toString
+		));
 	}
 	
 	// private constructor to prevent instantiation of this class.

--- a/src/main/java/com/kori_47/sudoku/InterpolatableCellGroup.java
+++ b/src/main/java/com/kori_47/sudoku/InterpolatableCellGroup.java
@@ -4,12 +4,12 @@
 package com.kori_47.sudoku;
 
 /**
- * This represents a {@link CellGroup} whose region<i>(the {@link Cell}s in the {@code CellGroup})</i> 
- * can easily be determined using a simple formula when given the starting position/{@link Cell} 
- * or end position/{@code Cell} and the size of the {@code CellGroup}. {@link Row}s and 
- * {@link Column}s are examples of {@code InterpolatableCellGroup}s. A {@link LatinSquare} is also 
+ * This represents a {@link CellGroup} whose region <i>(the {@link Cell}s in the {@code CellGroup})</i> 
+ * can easily be determined <i>(interpolated)</i> using a simple formula when given the {@link #startCell()
+ * starting position} or {@link #endCell() end position} and the size of the {@code CellGroup}. {@link Row}s
+ * and {@link Column}s are examples of {@code InterpolatableCellGroup}s. A {@link LatinSquare} is also 
  * a special type of an {@code InterpolatableCellGroup} since it's region can be easily calculated 
- * when given the first {@code Cell} and size of the {@code LatinSquare}.
+ * when given the first/last {@code Cell} and size of the {@code LatinSquare}.
  * 
  * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
  *

--- a/src/main/java/com/kori_47/sudoku/LatinSquare.java
+++ b/src/main/java/com/kori_47/sudoku/LatinSquare.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * A {@code LatinSquare} is an <i>n × n</i> matrix filled with <i>n</i> different {@link Symbol}s,
+ * A {@code LatinSquare} is an <i>n * n</i> matrix filled with <i>n</i> different {@link Symbol}s,
  * such that entries in each {@link Row} and {@link Column} are distinct. This interface describes a
  * {@code LatinSquare} where <i>n</i> is the {@link #size()} of the {@code LatinSquare} and {@link #symbols()}
  * is the set of {@code Symbol}s that can be used as entries on this {@code LatinSquare}.

--- a/src/main/java/com/kori_47/sudoku/SimpleLatinSquare.java
+++ b/src/main/java/com/kori_47/sudoku/SimpleLatinSquare.java
@@ -141,7 +141,7 @@ class SimpleLatinSquare<V> implements LatinSquare<V> {
 				Cell<V> cell1 = cr.getCell(x, cr.y()).get();
 				Cell<V> cell2 = nr.getCell(x, nr.y()).get();
 				
-				Cells.swapCellProperties(cell1, cell2);
+				Cells.swapCellSymbols(cell1, cell2);
 			}
 		}		
 	}
@@ -158,7 +158,7 @@ class SimpleLatinSquare<V> implements LatinSquare<V> {
 				Cell<V> cell1 = cc.getCell(cc.x(), y).get();
 				Cell<V> cell2 = nc.getCell(nc.x(), y).get();
 				
-				Cells.swapCellProperties(cell1, cell2);
+				Cells.swapCellSymbols(cell1, cell2);
 			}
 		}		
 	}

--- a/src/main/java/com/kori_47/sudoku/Sudoku.java
+++ b/src/main/java/com/kori_47/sudoku/Sudoku.java
@@ -146,7 +146,7 @@ public interface Sudoku<V> extends LatinSquare<V> {
 	 * @since Sat, 28 Dec 2019 11:30:27
 	 * 
 	 * @see Sudoku
-	 * @see BoxSudokuVariant
+	 * @see BoxBlocksSudokuVariant
 	 */
 	static interface SudokuVariant {
 
@@ -176,7 +176,7 @@ public interface Sudoku<V> extends LatinSquare<V> {
 	}
 	
 	/**
-	 * This represent the properties needed to describe a valid {@link Sudoku} with equally sized box shaped
+	 * This represents the properties needed to describe a valid {@link Sudoku} with equally sized box shaped
 	 * {@link Block}s, i.e. all the {@code Block}s have the same number of {@link Row}s and {@link Column}s.
 	 * Examples of {@code Sudoku}s that can be described by this variant are the famous <strong><i>9x9</i></strong>
 	 * classical {@code Sudoku}, the <strong><i>6x6</i></strong> {@code Sudoku}, the <strong><i>25x25</i></strong>
@@ -377,7 +377,7 @@ public interface Sudoku<V> extends LatinSquare<V> {
 			return sudoku.cells().values().stream()
 					.filter(cell -> cell.x() >= x && x < x1)
 					.filter(cell -> cell.y() >= y && y < y1)
-					.collect(toMap(cell -> cell.id(), cell -> cell));
+					.collect(toMap(Cell::id, cell -> cell));
 		}
 	}
 }

--- a/src/test/java/com/kori_47/sudoku/BlockTest.java
+++ b/src/test/java/com/kori_47/sudoku/BlockTest.java
@@ -1,0 +1,20 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+/**
+ * This is a test interface that implementors of the {@link Block} interface can use to test
+ * and validate their implementations.
+ * 
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Tue, 19 May 2020 13:22:44
+ */
+public interface BlockTest<T extends Block<Object>> extends UniqueCellGroupTest<T>, InterpolatableCellGroupTest<T> {
+
+	@Override
+	default void testCellGroupAccessors() {
+		InterpolatableCellGroupTest.super.testCellGroupAccessors();
+	}
+}

--- a/src/test/java/com/kori_47/sudoku/BoxBlockTest.java
+++ b/src/test/java/com/kori_47/sudoku/BoxBlockTest.java
@@ -1,0 +1,39 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test interface that implementors of the {@link BoxBlock} interface can use to test
+ * and validate their implementations.
+ * 
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Tue, 19 May 2020 13:47:06
+ */
+public interface BoxBlockTest extends BlockTest<BoxBlock<Object>> {
+
+	@Test
+	@Override
+	default void testCellGroupAccessors() {
+		BlockTest.super.testCellGroupAccessors();
+
+		BoxBlock<Object> value = createValue();
+
+		// assert that accessors return values in a valid range
+		assertTrue(value.blockColumns() > 0);
+		assertTrue(value.blockRows() > 0);
+		assertEquals((value.blockColumns() * value.blockRows()), value.size());
+	}
+
+	@Test
+	void testBlockRows();
+
+	@Test
+	void testBlockColumns();
+}

--- a/src/test/java/com/kori_47/sudoku/CellGroupTest.java
+++ b/src/test/java/com/kori_47/sudoku/CellGroupTest.java
@@ -1,0 +1,152 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test interface that implementors of the {@link CellGroup} interface can use to test
+ * and validate their implementations.
+ * 
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Sun, 22 Mar 2020 20:53:43
+ */
+public interface CellGroupTest<T extends CellGroup<Object>> extends TestHashCode<T>, FormattableTest<T> {
+	
+	/**
+	 * {@inheritDoc}
+	 * @implSpec
+	 * The default implementation for this {@code cellGroup} only checks that {@code cellGroup.toI()}
+	 * equals to {@link Formattables#toI(CellGroup)}.
+	 */
+	@Test
+	@Override
+	default void testToI() {
+		T cellGroup = createValue();
+		
+		assertEquals(Formattables.toI(cellGroup), cellGroup.toI());
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @implSpec
+	 * The default implementation for this {@code cellGroup} only checks that {@code cellGroup.toV()}
+	 * equals to {@link Formattables#toV(CellGroup)}.
+	 */
+	@Test
+	@Override
+	default void testToV() {
+		T cellGroup = createValue();
+		
+		assertEquals(Formattables.toV(cellGroup), cellGroup.toV());
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @implSpec
+	 * The default implementation for this {@code cellGroup} only checks that {@code cellGroup.toXY()}
+	 * equals to {@link Formattables#toXY(CellGroup)}.
+	 */
+	@Test
+	@Override
+	default void testToXY() {
+		T cellGroup = createValue();
+		
+		assertEquals(Formattables.toXY(cellGroup), cellGroup.toXY());
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @implSpec
+	 * The default implementation for this {@code cellGroup} only checks that {@code cellGroup.toXYI()}
+	 * equals to {@link Formattables#toXYI(CellGroup)}.
+	 */
+	@Test
+	@Override
+	default void testToXYI() {
+		T cellGroup = createValue();
+		
+		assertEquals(Formattables.toXYI(cellGroup), cellGroup.toXYI());
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @implSpec
+	 * The default implementation for this {@code cellGroup} only checks that {@code cellGroup.toXYV()}
+	 * equals to {@link Formattables#toXYV(CellGroup)}.
+	 */
+	@Test
+	@Override
+	default void testToXYV() {
+		T cellGroup = createValue();
+		
+		assertEquals(Formattables.toXYV(cellGroup), cellGroup.toXYV());
+	}
+	
+	/**
+	 * Tests a {@code CellGroup}'s {@link CellGroup#iterator() iterator()} method.
+	 */
+	@Test
+	default void testIterator() {
+		T cellGroup = createValue();
+		
+		// assert that the returned iterator isn't null.
+		assertNotNull(cellGroup.iterator());
+	}
+	
+	/**
+	 * Tests a {@code CellGroup}'s {@link CellGroup#spliterator() spliterator()} method.
+	 */
+	@Test
+	default void testSpliterator() {
+		T cellGroup = createValue();
+		
+		// assert that the returned spliterator isn't null.
+		assertNotNull(cellGroup.spliterator());
+	}
+	
+	/**
+	 * Tests a {@code CellGroup}'s accessor methods.
+	 */
+	@Test
+	default void testCellGroupAccessors() {
+		T cellGroup = createValue();
+		
+		// get accessor values
+		int size = cellGroup.size();
+		Map<String, Cell<Object>> cells = cellGroup.cells();
+		
+		// assert that the returned values are valid
+		assertTrue(size >= 0); // Size should never be negative
+		assertNotNull(cells); // cells should never be null
+		assertEquals(cells.size(), size); // for most CellGroups, this should be true
+		
+		// assert that multiple calls of the CellGroups accessors return the same value
+		// as long as no information has changed.
+		assertEquals(cellGroup.size(), size);
+		assertEquals(cellGroup.cells(), cells);
+		
+		assertEquals(cellGroup.size(), size);
+		assertEquals(cellGroup.cells(), cells);
+	}
+	
+	/**
+	 * Tests a {@code CellGroup}'s {@link CellGroup#getCell(String) getCell(String)} method.
+	 */
+	@Test
+	void testGetCellUsingCellId();
+	
+	/**
+	 * Tests a {@code CellGroup}'s {@link CellGroup#getCell(int, int) getCell(int, int)} method.
+	 */
+	@Test
+	void testGetCellUsingCellCoordinates();
+}

--- a/src/test/java/com/kori_47/sudoku/CellGroupsTest.java
+++ b/src/test/java/com/kori_47/sudoku/CellGroupsTest.java
@@ -1,0 +1,724 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+import static java.util.stream.Collectors.toMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Thu, 21 May 2020 20:05:15
+ */
+public class CellGroupsTest {
+
+	/**
+	 * Test {@link CellGroups#rowOf(String, int, java.util.Map, int)} creates and returns
+	 * the expected value.
+	 */
+	@Test
+	public void testRowOf() {
+		// create test values
+		Row<Object> row = CellGroups.rowOf(
+				"2", 5,
+				Arrays.asList(
+					Cells.of("0/2", 0, 2),
+					Cells.of("1/2", 1, 2),
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/2", 3, 2),
+					Cells.of("4/2", 4, 2)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			2);
+
+		Row<Object> row1 = CellGroups.rowOf(
+				"7", 7,
+				Arrays.asList(
+					Cells.of("0/6", 0, 6),
+					Cells.of("1/6", 1, 6),
+					Cells.of("2/6", 2, 6),
+					Cells.of("3/6", 3, 6),
+					Cells.of("4/6", 4, 6),
+					Cells.of("5/6", 5, 6),
+					Cells.of("6/6", 6, 6)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			6);
+
+		// assert the value returned isn't null
+		assertNotNull(row);
+		assertNotNull(row1);
+
+		// assert that the returned rows were initialized correctly
+		assertEquals(5, row.size());
+		assertEquals(5, row.cells().size());
+		assertEquals(2, row.y());
+		assertEquals("2", row.id());
+		assertEquals(Cells.of("0/2", 0, 2), row.startCell());
+		assertEquals(Cells.of("4/2", 4, 2), row.endCell());
+
+		assertEquals(7, row1.size());
+		assertEquals(7, row1.cells().size());
+		assertEquals(6, row1.y());
+		assertEquals("7", row1.id());
+		assertEquals(Cells.of("0/6", 0, 6), row1.startCell());
+		assertEquals(Cells.of("6/6", 6, 6), row1.endCell());
+
+		// assert that comparisons of the two blocks works as expected
+		assertNotEquals(row, row1);
+		assertTrue(row.compareTo(row1) < 0);
+	
+		// assert that the returned blocks have the expected cells
+		assertTrue(row.cells().containsKey("1/2"));
+		assertTrue(row.cells().containsKey("2/2"));
+		assertTrue(row.cells().containsKey("3/2"));
+		assertFalse(row.cells().containsKey("1/3"));
+	
+		assertTrue(row1.cells().containsKey("1/6"));
+		assertTrue(row1.cells().containsKey("2/6"));
+		assertTrue(row1.cells().containsKey("4/6"));
+		assertFalse(row1.cells().containsKey("5/5"));
+	}
+
+	/**
+	 * Test {@link CellGroups#rowOf(String, int, java.util.Map, int)} throws the appropriate
+	 * exceptions incase of invalid parameters.
+	 */
+	@Test
+	public void testRowOfExceptions() {
+		// assert that an IllegalException is thrown where appropriate
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.rowOf("2", 0, Arrays.asList(Cells.of("0/2", 0, 2)).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), 2)); // assert that we can't pass a size of 0
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.rowOf("2", 2, Arrays.asList(Cells.of("0/2", 0, 2)).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), 2)); // assert that # of cells given is equal to size given
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.rowOf("2", 1, Arrays.asList(Cells.of("0/2", 0, 2)).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), -2)); // assert that y >= 0
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.rowOf("2", 1, Arrays.asList(Cells.of("0/2", 0, 2)).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), 2)); // assert that y < size
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.rowOf("2", 3, Arrays.asList(
+						Cells.of("1/2", 1, 2),
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), 2)); // assert that the cells given have a valid x coordinate (0 to size - 1).
+
+		// assert that a NullPointerException is thrown where appropriate
+		assertThrows(NullPointerException.class, () -> 
+			CellGroups.rowOf(null, 1, Arrays.asList(Cells.of("0/0", 0, 0)).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), 0)); // assert that we can't pass a null id
+		assertThrows(NullPointerException.class, () ->  CellGroups.rowOf("", 1, null, 0)); // assert that we can't pass a null cells map
+	}
+
+	/**
+	 * Test {@link CellGroups#columnOf(String, int, java.util.Map, int)} creates and returns
+	 * the expected value.
+	 */
+	@Test
+	public void testColumnOf() {
+		// create test values
+		Column<Object> column = CellGroups.columnOf(
+				"2", 5,
+				Arrays.asList(
+					Cells.of("2/0", 2, 0),
+					Cells.of("2/1", 2, 1),
+					Cells.of("2/2", 2, 2),
+					Cells.of("2/3", 2, 3),
+					Cells.of("2/4", 2, 4)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			2);
+
+		Column<Object> column1 = CellGroups.columnOf(
+				"6", 7,
+				Arrays.asList(
+					Cells.of("5/0", 5, 0),
+					Cells.of("5/1", 5, 1),
+					Cells.of("5/2", 5, 2),
+					Cells.of("5/3", 5, 3),
+					Cells.of("5/4", 5, 4),
+					Cells.of("5/5", 5, 5),
+					Cells.of("5/6", 5, 6)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			5);
+
+		// assert the value returned isn't null
+		assertNotNull(column);
+		assertNotNull(column1);
+
+		// assert that the returned columns were initialized correctly
+		assertEquals(5, column.size());
+		assertEquals(5, column.cells().size());
+		assertEquals(2, column.x());
+		assertEquals("2", column.id());
+		assertEquals(Cells.of("2/0", 2, 0), column.startCell());
+		assertEquals(Cells.of("2/4", 2, 4), column.endCell());
+
+		assertEquals(7, column1.size());
+		assertEquals(7, column1.cells().size());
+		assertEquals(5, column1.x());
+		assertEquals("6", column1.id());
+		assertEquals(Cells.of("5/0", 5, 0), column1.startCell());
+		assertEquals(Cells.of("5/6", 5, 6), column1.endCell());
+
+		// assert that comparisons of the two blocks works as expected
+		assertNotEquals(column, column1);
+		assertTrue(column.compareTo(column1) < 0);
+	
+		// assert that the returned blocks have the expected cells
+		assertTrue(column.cells().containsKey("2/1"));
+		assertTrue(column.cells().containsKey("2/2"));
+		assertTrue(column.cells().containsKey("2/3"));
+		assertFalse(column.cells().containsKey("4/3"));
+	
+		assertTrue(column1.cells().containsKey("5/1"));
+		assertTrue(column1.cells().containsKey("5/2"));
+		assertTrue(column1.cells().containsKey("5/4"));
+		assertFalse(column1.cells().containsKey("5/9"));	
+	}
+
+	/**
+	 * Test {@link CellGroups#columnOf(String, int, java.util.Map, int)} throws the appropriate
+	 * exceptions incase of invalid parameters.
+	 */
+	@Test
+	public void testColumnOfExceptions() {
+		// assert that an IllegalException is thrown where appropriate
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.columnOf("2", 0, Arrays.asList(Cells.of("2/0", 2, 0)).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), 2)); // assert that we can't pass a size of 0
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.columnOf("2", 2, Arrays.asList(Cells.of("2/0", 2, 0)).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), 2)); // assert that # of cells given is equal to size given
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.columnOf("2", 1, Arrays.asList(Cells.of("2/0", 2, 0)).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), -2)); // assert that x >= 0
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.columnOf("2", 1, Arrays.asList(Cells.of("2/0", 2, 0)).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), 2)); // assert that x < size
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.columnOf("2", 3, Arrays.asList(
+						Cells.of("2/1", 2, 1),
+						Cells.of("2/2", 2, 2),
+						Cells.of("2/3", 2, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), 2)); // assert that the cells given have a valid x coordinate (0 to size - 1).
+
+		// assert that a NullPointerException is thrown where appropriate
+		assertThrows(NullPointerException.class, () -> 
+			CellGroups.columnOf(null, 1, Arrays.asList(Cells.of("0/0", 0, 0)).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)), 0)); // assert that we can't pass a null id
+		assertThrows(NullPointerException.class, () ->  CellGroups.columnOf("2", 1, null, 0)); // assert that we can't pass a null cells map
+	}
+
+	/**
+	 * Test {@link CellGroups#boxBlockOf(String, int, java.util.Map, Cell, int, int)} and it's derivertive
+	 * {@link CellGroups#boxBlockOf(String, int, java.util.Map, Cell, int, int)}.
+	 */
+	@Test
+	public void testBoxBlockOf() {
+		// create test values
+		BoxBlock<Object> boxBlock = CellGroups.boxBlockOf(
+				"4", 4,
+				Arrays.asList(
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/2", 3, 2),
+					Cells.of("2/3", 2, 3),
+					Cells.of("3/3", 3, 3)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)),
+				Cells.of("2/2", 2, 2),
+				2, 2);
+
+		BoxBlock<Object> boxBlock1 = CellGroups.boxBlockOf(
+				"1", 4,
+				Arrays.asList(
+					Cells.of("0/0", 0, 0),
+					Cells.of("1/0", 1, 0),
+					Cells.of("0/1", 0, 1),
+					Cells.of("1/1", 1, 1)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)),
+				Cells.of("0/0", 0, 0),
+				Cells.of("1/1", 1, 1));
+
+		// assert the value returned isn't null
+		assertNotNull(boxBlock);
+		assertNotNull(boxBlock1);
+
+		// assert that the returned blocks were initialized correctly
+		assertEquals(4, boxBlock.size());
+		assertEquals(4, boxBlock.cells().size());
+		assertEquals(2, boxBlock.blockColumns());
+		assertEquals(2, boxBlock.blockRows());
+		assertEquals("4", boxBlock.id());
+		assertEquals(Cells.of("2/2", 2, 2), boxBlock.startCell());
+		assertEquals(Cells.of("3/3", 3, 3), boxBlock.endCell());
+
+		assertEquals(4, boxBlock1.size());
+		assertEquals(4, boxBlock1.cells().size());
+		assertEquals(2, boxBlock1.blockColumns());
+		assertEquals(2, boxBlock1.blockRows());
+		assertEquals("1", boxBlock1.id());
+		assertEquals(Cells.of("0/0", 0, 0), boxBlock1.startCell());
+		assertEquals(Cells.of("1/1", 1, 1), boxBlock1.endCell());
+
+		// assert that comparisons of the two blocks works as expected
+		assertNotEquals(boxBlock, boxBlock1);
+		assertTrue(boxBlock.compareTo(boxBlock1) > 0);
+
+		// assert that the returned blocks have the expected cells
+		assertTrue(boxBlock.cells().containsKey("3/2"));
+		assertTrue(boxBlock.cells().containsKey("2/3"));
+		assertFalse(boxBlock.cells().containsKey("0/3"));
+
+		assertTrue(boxBlock1.cells().containsKey("1/0"));
+		assertTrue(boxBlock1.cells().containsKey("0/1"));
+		assertFalse(boxBlock1.cells().containsKey("2/2"));
+	}
+
+	/**
+	 * Test {@link CellGroups#boxBlockOf(String, int, java.util.Map, Cell, int, int)} throws the appropriate
+	 * exceptions incase of invalid parameters.
+	 * 
+	 * @see #testBoxBlockOf1Exceptions()
+	 */
+	@Test
+	public void testBoxBlockOfExceptions() {
+		// assert that an IllegalException is thrown where appropriate
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.boxBlockOf(
+					"4", 0,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 2, 2),
+					2, 2
+			)
+		); // assert that we can't pass a size of 0
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.boxBlockOf(
+					"4", 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 2, 2),
+					2, 2
+			)
+		); // assert that # of cells given is equal to size given
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.boxBlockOf(
+					"4", 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 2, 2),
+					0, 2
+			)
+		); // assert that blockRow >= 1
+		assertThrows(IllegalArgumentException.class, () ->
+			CellGroups.boxBlockOf(
+					"4", 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 2, 2),
+					2, 0
+			)
+		); // assert that blockColumn >= 1
+		assertThrows(IllegalArgumentException.class, () ->
+			CellGroups.boxBlockOf(
+					"4", 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("4/4", 4, 4),
+					2, 2
+			)
+		); // assert that startCell is in the provided cells Map
+		assertThrows(IllegalArgumentException.class, () ->
+			CellGroups.boxBlockOf(
+					"4", 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 4, 4),
+					2, 1
+			)
+		); // assert that startCell is in the provided cells Map
+
+		// assert that a SudokuException is thrown where appropriate
+		assertThrows(SudokuException.class, () ->
+			CellGroups.boxBlockOf(
+					"4", 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 4, 4),
+					2, 2
+			)
+		); // assert that the endCell can be derived from the given properties
+
+		// assert that a SudokuException is thrown where appropriate
+		assertThrows(SudokuException.class, () ->
+			CellGroups.boxBlockOf(
+					"4", 3,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 4, 4),
+					Cells.of("3/3", 3, 3)
+			)
+		); // assert that the product of the calculated blockRows and blockColumns is equal to the given size
+
+		// assert that a NullPointerException is thrown where appropriate
+		assertThrows(NullPointerException.class, () -> 
+			CellGroups.boxBlockOf(
+					null, 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 2, 2),
+					2, 2
+			)
+		); // assert that we can't pass a null id
+		assertThrows(NullPointerException.class, () ->  CellGroups.boxBlockOf(
+				"2", 4,
+				Arrays.asList(
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/2", 3, 2),
+					Cells.of("2/3", 2, 3),
+					Cells.of("3/3", 3, 3)
+				).stream().
+				collect(toMap(cell -> cell.id(), cell -> cell)), 
+				null, 
+				2, 2
+			)
+		); // assert that we can't pass a null startCell
+		assertThrows(NullPointerException.class, () ->  CellGroups.boxBlockOf("2", 4, null, Cells.of("2/2", 2, 2), 2, 2)); // assert that we can't pass a null cells map
+	}
+
+	/**
+	 * Test {@link CellGroups#boxBlockOf(String, int, java.util.Map, Cell, Cell)} throws the appropriate
+	 * exceptions incase of invalid parameters.
+	 * 
+	 * @see #testBoxBlockOfExceptions()
+	 */
+	@Test
+	public void testBoxBlockOf1Exceptions() {
+		// assert that an IllegalException is thrown where appropriate
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.boxBlockOf(
+					"4", 0,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/3", 3, 3)
+			)
+		); // assert that we can't pass a size of 0
+		assertThrows(IllegalArgumentException.class, () -> 
+			CellGroups.boxBlockOf(
+					"4", 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/3", 3, 3)
+			)
+		); // assert that # of cells given is equal to size given
+		assertThrows(IllegalArgumentException.class, () ->
+			CellGroups.boxBlockOf(
+					"4", 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("4/4", 2, 2),
+					Cells.of("3/3", 3, 3)
+			)
+		); // assert that startCell is in the provided cells Map
+		assertThrows(IllegalArgumentException.class, () ->
+			CellGroups.boxBlockOf(
+					"4", 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 2, 2),
+					Cells.of("4/4", 3, 3)
+			)
+		); // assert that endCell is in the provided cells Map
+
+		// assert that a NullPointerException is thrown where appropriate
+		assertThrows(NullPointerException.class, () -> 
+			CellGroups.boxBlockOf(
+					null, 4,
+					Arrays.asList(
+						Cells.of("2/2", 2, 2),
+						Cells.of("3/2", 3, 2),
+						Cells.of("2/3", 2, 3),
+						Cells.of("3/3", 3, 3)
+					).stream().
+					collect(toMap(cell -> cell.id(), cell -> cell)),
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/3", 3, 3)
+			)
+		); // assert that we can't pass a null id
+		assertThrows(NullPointerException.class, () ->  CellGroups.boxBlockOf(
+				"2", 4,
+				Arrays.asList(
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/2", 3, 2),
+					Cells.of("2/3", 2, 3),
+					Cells.of("3/3", 3, 3)
+				).stream().
+				collect(toMap(cell -> cell.id(), cell -> cell)), 
+				null, 
+				Cells.of("3/3", 3, 3)
+			)
+		); // assert that we can't pass a null startCell
+		assertThrows(NullPointerException.class, () ->  CellGroups.boxBlockOf(
+				"2", 4,
+				Arrays.asList(
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/2", 3, 2),
+					Cells.of("2/3", 2, 3),
+					Cells.of("3/3", 3, 3)
+				).stream().
+				collect(toMap(cell -> cell.id(), cell -> cell)), 
+				Cells.of("2/2", 2, 2), 
+				null
+			)
+		); // assert that we can't pass a null endCell
+		assertThrows(NullPointerException.class, () ->  CellGroups.boxBlockOf("2", 4, null, Cells.of("2/2", 2, 2), Cells.of("3/3", 3, 3))); // assert that we can't pass a null cells map
+	}
+
+	/**
+	 * Test {@link CellGroups#defaultRowFactory()} creates and returns the expected value.
+	 */
+	@Test
+	public void testDefaultRowFactory() {
+		// assert the the returned RowFactory isn't null
+		assertNotNull(CellGroups.defaultRowFactory());
+
+		// create test values
+		Row<Object> row = CellGroups.defaultRowFactory().createRow(
+				"1", 5,
+				Arrays.asList(
+					Cells.of("0/0", 0, 0),
+					Cells.of("1/0", 1, 0),
+					Cells.of("2/0", 2, 0),
+					Cells.of("3/0", 3, 0),
+					Cells.of("4/0", 4, 0)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			0);
+
+		Row<Object> row1 = CellGroups.defaultRowFactory().createRow(
+				"2", 3,
+				Arrays.asList(
+					Cells.of("0/1", 0, 1),
+					Cells.of("1/1", 1, 1),
+					Cells.of("2/1", 2, 1)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			1);
+
+		// assert the values created aren't null
+		assertNotNull(row);
+		assertNotNull(row1);
+
+		// assert that the returned rows were initialized correctly
+		assertEquals(5, row.size());
+		assertEquals(5, row.cells().size());
+		assertEquals(0, row.y());
+		assertEquals("1", row.id());
+		assertEquals(Cells.of("0/0", 0, 0), row.startCell());
+		assertEquals(Cells.of("4/0", 4, 0), row.endCell());
+
+		assertEquals(3, row1.size());
+		assertEquals(3, row1.cells().size());
+		assertEquals(1, row1.y());
+		assertEquals("2", row1.id());
+		assertEquals(Cells.of("0/1", 0, 1), row1.startCell());
+		assertEquals(Cells.of("2/1", 2, 1), row1.endCell()); 
+	}
+
+	/**
+	 * Test {@link CellGroups#defaultColumnFactory()} creates and returns the expected value.
+	 */
+	@Test
+	public void testDefaultColumnFactory() {
+		// assert the the returned ColumnFactory isn't null
+		assertNotNull(CellGroups.defaultColumnFactory());
+
+		// create test values
+		Column<Object> column = CellGroups.defaultColumnFactory().createColumn(
+				"9", 10,
+				Arrays.asList(
+					Cells.of("9/0", 9, 0),
+					Cells.of("9/1", 9, 1),
+					Cells.of("9/2", 9, 2),
+					Cells.of("9/3", 9, 3),
+					Cells.of("9/4", 9, 4),
+					Cells.of("9/5", 9, 5),
+					Cells.of("9/6", 9, 6),
+					Cells.of("9/7", 9, 7),
+					Cells.of("9/8", 9, 8),
+					Cells.of("9/9", 9, 9)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			9);
+
+		Column<Object> column1 = CellGroups.columnOf(
+				"1", 1,
+				Arrays.asList(
+					Cells.of("0/0", 0, 0)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			0);
+
+		// assert the values created aren't null
+		assertNotNull(column);
+		assertNotNull(column1);
+
+		// assert that the returned columns were initialized correctly
+		assertEquals(10, column.size());
+		assertEquals(10, column.cells().size());
+		assertEquals(9, column.x());
+		assertEquals("9", column.id());
+		assertEquals(Cells.of("9/0", 9, 0), column.startCell());
+		assertEquals(Cells.of("9/9", 9, 9), column.endCell());
+
+		assertEquals(1, column1.size());
+		assertEquals(1, column1.cells().size());
+		assertEquals(0, column1.x());
+		assertEquals("1", column1.id());
+		assertEquals(Cells.of("0/0", 0, 0), column1.startCell());
+		assertEquals(Cells.of("0/0", 0, 0), column1.endCell());
+	}
+
+	/**
+	 * Test {@link CellGroups#defaultBoxBlockFactory()} creates and returns the expected value.
+	 */
+	@Test
+	public void testDefaultBoxBlockFactory() {
+		// assert the the returned BoxBlockFactory isn't null
+		assertNotNull(CellGroups.defaultBoxBlockFactory());
+
+		BoxBlock<Object> boxBlock = (BoxBlock<Object>) CellGroups.defaultBoxBlockFactory().createBlock(
+			"4", 6,
+			Arrays.asList(
+				Cells.of("3/2", 3, 2),
+				Cells.of("4/2", 4, 2),
+				Cells.of("5/2", 5, 2),
+				Cells.of("3/3", 3, 3),
+				Cells.of("4/3", 4, 3),
+				Cells.of("5/3", 5, 3)
+			).stream().collect(toMap(cell -> cell.id(), cell -> cell)),
+			Cells.of("3/2", 3, 2),
+			Cells.of("5/3", 5, 3)
+		);
+
+		BoxBlock<Object> boxBlock1 = (BoxBlock<Object>) CellGroups.defaultBoxBlockFactory().createBlock(
+			"3", 10,
+			Arrays.asList(
+				Cells.of("0/2", 0, 2),
+				Cells.of("1/2", 1, 2),
+				Cells.of("2/2", 2, 2),
+				Cells.of("3/2", 3, 2),
+				Cells.of("4/2", 4, 2),
+				Cells.of("0/3", 0, 3),
+				Cells.of("1/3", 1, 3),
+				Cells.of("2/3", 2, 3),
+				Cells.of("3/3", 3, 3),
+				Cells.of("4/3", 4, 3)
+			).stream().collect(toMap(cell -> cell.id(), cell -> cell)),
+			Cells.of("0/2", 0, 2),
+			Cells.of("4/3", 4, 3)
+		);
+
+		// assert the value returned isn't null
+		assertNotNull(boxBlock);
+		assertNotNull(boxBlock1);
+
+		// assert that the returned blocks were initialized correctly
+		assertEquals(6, boxBlock.size());
+		assertEquals(6, boxBlock.cells().size());
+		assertEquals(3, boxBlock.blockColumns());
+		assertEquals(2, boxBlock.blockRows());
+		assertEquals("4", boxBlock.id());
+		assertEquals(Cells.of("3/2", 3, 2), boxBlock.startCell());
+		assertEquals(Cells.of("5/3", 5, 3), boxBlock.endCell());
+
+		assertEquals(10, boxBlock1.size());
+		assertEquals(10, boxBlock1.cells().size());
+		assertEquals(5, boxBlock1.blockColumns());
+		assertEquals(2, boxBlock1.blockRows());
+		assertEquals("3", boxBlock1.id());
+		assertEquals(Cells.of("0/2", 0, 2), boxBlock1.startCell());
+		assertEquals(Cells.of("4/3", 4, 3), boxBlock1.endCell());
+	}
+
+	/**
+	 * Test {@link CellGroups#defaultUniqueCellGroupComparator()} performs comparisons as expected.
+	 */
+	@Test
+	public void testDefaultUniqueCellGroupComparator() {
+		// create test values
+		CellGroups.defaultUniqueCellGroupComparator();
+	}
+}

--- a/src/test/java/com/kori_47/sudoku/CellsTest.java
+++ b/src/test/java/com/kori_47/sudoku/CellsTest.java
@@ -172,6 +172,37 @@ public class CellsTest {
 	}
 	
 	/**
+	 * Test {@link Cells#deepEquals(Cell, Object)} static utility method.
+	 */
+	@Test
+	public void testDeepEquals() {
+		// create Cells for testing for equality
+		Cell<Integer> cell1 = Cells.of("1", 2, 3);
+		Cell<Character> cell2 = Cells.of("2", 3, 2);
+		Cell<Character> cell3 = Cells.of("2", 3, 2, Symbols.of(Integer.valueOf(0), Character.valueOf(' ')));
+		Cell<Character> cell4 = Cells.of("2", 3, 2, Symbols.of(Integer.valueOf(1), Character.valueOf('A')));
+		Cell<Character> cell5 = Cells.of("2", 3, 2, Symbols.of(Integer.valueOf(0), Character.valueOf(' ')));
+		
+		// assert that the Cell method works as intended
+		assertFalse(Cells.deepEquals(cell1, cell2)); // cell1 and cell2 aren't equal
+		assertTrue(Cells.deepEquals(cell1, cell1));  // a Cell is equal to itself
+		assertTrue(Cells.deepEquals(cell2, cell2));  // a Cell is equal to itself
+		assertTrue(Cells.deepEquals(cell3, cell5));  // cell3 and cell5 should be equal
+		assertFalse(Cells.deepEquals(cell2, cell3));  // cell2 and cell3 should not be equal
+		assertFalse(Cells.deepEquals(cell2, cell4));  // cell2 and cell4 should not be equal
+		assertFalse(Cells.deepEquals(cell3, cell4));  // cell3 and cell4 should not be equal, they have different Symbols
+		assertFalse(Cells.deepEquals(cell2, Symbols.of(Integer.valueOf(0), Character.valueOf(' '))));  // comparison to a non Cell should be false
+		assertFalse(Cells.deepEquals(cell1, null));  // comparison to null should always return false
+		
+		// assert that after modification of a Cell, it's equality results is affected
+		cell2.changeSymbol(Symbols.of(Integer.valueOf(1), Character.valueOf('A'))); // assign a value to cell2
+		assertTrue(Cells.deepEquals(cell2, cell4));  // cell2 and cell4 should now be equal
+		
+		// assert that the method throws a NullPointerException when the 1st parameter is null
+		assertThrows(NullPointerException.class, () -> Cells.equals(null, cell2));
+	}
+	
+	/**
 	 * Test {@link Cells#toString(Cell, String)} and it's derivertives.
 	 */
 	@Test
@@ -187,5 +218,39 @@ public class CellsTest {
 		assertEquals("Cell{id=1, coord=(x:2, y:3), value=[*]}", Cells.toString(cell1, "*"));
 		assertEquals("Cell{id=2, coord=(x:3, y:2), value=[-]}", Cells.toString(cell2));
 		assertEquals("Cell{id=2, coord=(x:3, y:2), value=[Symbol{id=0, value=0}]}", Cells.toString(cell3));
+	}
+	
+	/**
+	 * Test {@link Cells#swapCellSymbols(Cell, Cell)} static utility method.
+	 */
+	@Test
+	public void testSwapCellSymbols() {
+		// create Cells for testing the swapCellProperties method
+		Cell<Integer> cell1 = Cells.of("1", 2, 3);
+		Cell<Character> cell2 = Cells.of("2", 3, 2);
+		Cell<Integer> cell3 = Cells.of("2", 3, 2, Symbols.of(Integer.valueOf(0), Integer.valueOf(0)));
+		Cell<Character> cell4 = Cells.of("2", 3, 2, Symbols.of(Integer.valueOf(1), Character.valueOf('A')));
+		Cell<Character> cell5 = Cells.of("1/0", 1, 0, Symbols.of(Integer.valueOf(9), Character.valueOf('I')));
+		Cell<Character> cell6 = Cells.of("2/1", 2, 1, Symbols.of(Integer.valueOf(5), Character.valueOf('E')));
+		// Cell copies
+		Cell<Integer> cell1Copy = Cells.of(cell1.id(), cell1.x(), cell1.y(), cell1.symbol().orElse(null));
+		Cell<Character> cell2Copy = Cells.of(cell2.id(), cell2.x(), cell2.y(), cell2.symbol().orElse(null));
+		Cell<Integer> cell3Copy = Cells.of(cell3.id(), cell3.x(), cell3.y(), cell3.symbol().orElse(null));
+		Cell<Character> cell4Copy = Cells.of(cell4.id(), cell4.x(), cell4.y(), cell4.symbol().orElse(null));
+		Cell<Character> cell5Copy = Cells.of(cell5.id(), cell5.x(), cell5.y(), cell5.symbol().orElse(null));
+		Cell<Character> cell6Copy = Cells.of(cell6.id(), cell6.x(), cell6.y(), cell6.symbol().orElse(null));
+		
+		// swap the cell pairs
+		Cells.swapCellSymbols(cell1, cell3);
+		Cells.swapCellSymbols(cell2, cell4);
+		Cells.swapCellSymbols(cell5, cell6);
+		
+		// check that the swapping worked as expected
+		assertEquals(cell1.symbol().orElse(null), cell3Copy.symbol().orElse(null)); // cell1's symbol should now be equal to what cell3's symbol was, i.e cell3Copy symbol
+		assertEquals(cell3.symbol().orElse(null), cell1Copy.symbol().orElse(null)); // cell3's symbol should now be equal to what cell1's symbol was, i.e cell1Copy symbol
+		assertEquals(cell2.symbol().orElse(null), cell4Copy.symbol().orElse(null)); // cell2's symbol should now be equal to what cell4's symbol was, i.e cell4Copy symbol
+		assertEquals(cell4.symbol().orElse(null), cell2Copy.symbol().orElse(null)); // cell4's symbol should now be equal to what cell2's symbol was, i.e cell2Copy symbol
+		assertEquals(cell5.symbol().orElse(null), cell6Copy.symbol().orElse(null)); // cell5's symbol should now be equal to what cell6's symbol was, i.e cell6Copy symbol
+		assertEquals(cell6.symbol().orElse(null), cell5Copy.symbol().orElse(null)); // cell6's symbol should now be equal to what cell5's symbol was, i.e cell5Copy symbol
 	}
 }

--- a/src/test/java/com/kori_47/sudoku/ColumnTest.java
+++ b/src/test/java/com/kori_47/sudoku/ColumnTest.java
@@ -1,0 +1,32 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test interface that implementors of the {@link Column} interface can use to test
+ * and validate their implementations.
+ * 
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Mon, 23 Mar 2020 12:33:15
+ */
+public interface ColumnTest extends UniqueCellGroupTest<Column<Object>>, InterpolatableCellGroupTest<Column<Object>> {
+	
+	@Test
+	@Override
+	default void testCellGroupAccessors() {
+		UniqueCellGroupTest.super.testCellGroupAccessors();
+		InterpolatableCellGroupTest.super.testCellGroupAccessors();
+
+		Column<Object> column = createValue();
+
+		// assert that the index of this Column is a positive number but less than size
+		assertTrue(column.x() >= 0);
+		assertTrue(column.x() < column.size());
+	}
+}

--- a/src/test/java/com/kori_47/sudoku/InterpolatableCellGroupTest.java
+++ b/src/test/java/com/kori_47/sudoku/InterpolatableCellGroupTest.java
@@ -1,0 +1,42 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test interface that implementors of the {@link InterpolatableCellGroup} interface can use to test
+ * and validate their implementations.
+ * 
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Mon, 23 Mar 2020 13:25:41
+ */
+public interface InterpolatableCellGroupTest<T extends InterpolatableCellGroup<Object>> extends CellGroupTest<T> {
+	
+	@Test
+	@Override
+	default void testCellGroupAccessors() {
+		CellGroupTest.super.testCellGroupAccessors();
+		T cellGroup = createValue();
+		T cellGroup1 = createEqualValue();
+		T cellGroup2 = createNonEqualValue();
+		
+		// assert that the return values aren't null
+		assertNotNull(cellGroup.startCell());
+		assertNotNull(cellGroup.endCell());
+		assertNotNull(cellGroup1.startCell());
+		assertNotNull(cellGroup1.endCell());
+		assertNotNull(cellGroup2.startCell());
+		assertNotNull(cellGroup2.endCell());
+	}
+
+	@Test
+	void testStartCell();
+
+	@Test
+	void testEndCell();
+}

--- a/src/test/java/com/kori_47/sudoku/ReferenceBoxBlockImplementationTest.java
+++ b/src/test/java/com/kori_47/sudoku/ReferenceBoxBlockImplementationTest.java
@@ -1,0 +1,224 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+import static java.util.stream.Collectors.toMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This class is used to define and run tests on the reference implementation of {@link BoxBlock},
+ * i.e, the {@code BoxBlock} instances returned by {@link CellGroups#boxBlockOf(String, int, Map, Cell, int, int)}
+ * method and it's derivetives.
+ * 
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Thu, 21 May 2020 16:35:11
+ */
+public class ReferenceBoxBlockImplementationTest implements BoxBlockTest {
+
+	@Override
+	public BoxBlock<Object> createSmallerValue() {
+		Map<String, Cell<Object>> cells = Arrays.asList(
+			Cells.of("0/0", 0, 0),
+			Cells.of("1/0", 1, 0),
+			Cells.of("2/0", 2, 0),
+			Cells.of("0/1", 0, 1),
+			Cells.of("1/1", 1, 1),
+			Cells.of("2/1", 2, 1),
+			Cells.of("0/2", 0, 2),
+			Cells.of("1/2", 1, 2),
+			Cells.of("2/2", 2, 2)
+		).stream().collect(toMap(cell -> cell.id(), cell -> cell));
+
+		return CellGroups.boxBlockOf("1", 9, cells, Cells.of("0/0", 0, 0), 3, 3);
+	}
+
+	@Override
+	public BoxBlock<Object> createEqualValue() {
+		Map<String, Cell<Object>> cells = Arrays.asList(
+			Cells.of("3/3", 3, 3),
+			Cells.of("4/3", 4, 3),
+			Cells.of("5/3", 5, 3),
+			Cells.of("3/4", 3, 4),
+			Cells.of("4/4", 4, 4),
+			Cells.of("5/4", 5, 4),
+			Cells.of("3/5", 3, 5),
+			Cells.of("4/5", 4, 5),
+			Cells.of("5/5", 5, 5)
+		).stream().collect(toMap(cell -> cell.id(), cell -> cell));
+		
+		return CellGroups.boxBlockOf("5", 9, cells, Cells.of("3/3", 3, 3), 3, 3);
+	}
+
+	@Override
+	public BoxBlock<Object> createLargerValue() {
+		Map<String, Cell<Object>> cells = Arrays.asList(
+			Cells.of("6/6", 6, 6),
+			Cells.of("7/6", 7, 6),
+			Cells.of("8/6", 8, 6),
+			Cells.of("6/7", 6, 7),
+			Cells.of("7/7", 7, 7),
+			Cells.of("8/7", 8, 7),
+			Cells.of("6/8", 6, 8),
+			Cells.of("7/8", 7, 8),
+			Cells.of("8/8", 8, 8)
+		).stream().collect(toMap(cell -> cell.id(), cell -> cell));
+	
+		return CellGroups.boxBlockOf("9", 9, cells, Cells.of("6/6", 6, 6), 3, 3);
+	}
+
+	@Test
+	@Override
+	public void testGetCellUsingCellId() {
+		BoxBlock<Object> blockBox = createValue();
+
+		// get some Cell using their id's
+		Optional<Cell<Object>> cell1 = blockBox.getCell("3/3");
+		Optional<Cell<Object>> cell2 = blockBox.getCell("5/4");
+		Optional<Cell<Object>> cell3 = blockBox.getCell("6/5");
+
+		// assert that getting an available or non available Cell using id
+		// returns correct availability results
+		assertTrue(cell1.isPresent());
+		assertTrue(cell2.isPresent());
+		assertFalse(cell3.isPresent());
+
+		// assert that getting a Cell using id returns a valid result
+		assertEquals(cell1.get(), Cells.of("3/3", 3, 3));
+		assertEquals(cell2.get(), Cells.of("5/4", 5, 4));
+	}
+
+	@Test
+	@Override
+	public void testGetCellUsingCellCoordinates() {
+		BoxBlock<Object> blockBox = createValue();
+
+		// get some Cell using their coordinates
+		Optional<Cell<Object>> cell1 = blockBox.getCell(3, 3);
+		Optional<Cell<Object>> cell2 = blockBox.getCell(5, 4);
+		Optional<Cell<Object>> cell3 = blockBox.getCell(6, 5);
+
+		// assert that getting an available or non available Cell using coordinates
+		// returns correct availability results
+		assertTrue(cell1.isPresent());
+		assertTrue(cell2.isPresent());
+		assertFalse(cell3.isPresent());
+
+		// assert that getting a Cell using coordinates returns a valid result
+		assertEquals(cell1.get(), Cells.of("3/3", 3, 3));
+		assertEquals(cell2.get(), Cells.of("5/4", 5, 4));
+	}
+
+
+	@Test
+	@Override
+	public void testStartCell() {
+		BoxBlock<Object> boxBlock1 = createSmallerValue();
+		BoxBlock<Object> boxBlock2 = createValue();
+		BoxBlock<Object> boxBlock3 = createLargerValue();
+		BoxBlock<Object> boxBlock4 = createNonEqualValue();
+
+		// assert that we have the correct start Cells
+		assertEquals(boxBlock1.startCell(), Cells.of("0/0", 0, 0));
+		assertEquals(boxBlock2.startCell(), Cells.of("3/3", 3, 3));
+		assertEquals(boxBlock3.startCell(), Cells.of("6/6", 6, 6));
+		assertEquals(boxBlock4.startCell(), Cells.of("3/0", 3, 0));
+	}
+
+	@Test
+	@Override
+	public void testEndCell() {
+		BoxBlock<Object> boxBlock1 = createSmallerValue();
+		BoxBlock<Object> boxBlock2 = createValue();
+		BoxBlock<Object> boxBlock3 = createLargerValue();
+		BoxBlock<Object> boxBlock4 = createNonEqualValue();
+
+		// assert that we have the correct end Cells
+		assertEquals(boxBlock1.endCell(), Cells.of("2/2", 2, 2));
+		assertEquals(boxBlock2.endCell(), Cells.of("5/5", 5, 5));
+		assertEquals(boxBlock3.endCell(), Cells.of("8/8", 8, 8));
+		assertEquals(boxBlock4.endCell(), Cells.of("5/2", 5, 2));
+	}
+
+	@Test
+	@Override
+	public void testBlockRows() {
+		BoxBlock<Object> boxBlock1 = createValue();
+		BoxBlock<Object> boxBlock2 = createNonEqualValue();
+
+		// assert that we have the correct blockRows values
+		assertEquals(boxBlock1.blockRows(), 3);
+		assertEquals(boxBlock2.blockRows(), 3);
+	}
+
+	@Test
+	@Override
+	public void testBlockColumns() {
+		BoxBlock<Object> boxBlock1 = createValue();
+		BoxBlock<Object> boxBlock2 = createNonEqualValue();
+
+		// assert that we have the correct blockColumns values
+		assertEquals(boxBlock1.blockColumns(), 3);
+		assertEquals(boxBlock2.blockColumns(), 3);
+	}
+
+	@Override
+	public BoxBlock<Object> createAnotherEqualValue() {
+		Map<String, Cell<Object>> cells = Arrays.asList(
+			Cells.of("3/3", 3, 3),
+			Cells.of("4/3", 4, 3),
+			Cells.of("5/3", 5, 3),
+			Cells.of("3/4", 3, 4),
+			Cells.of("4/4", 4, 4),
+			Cells.of("5/4", 5, 4),
+			Cells.of("3/5", 3, 5),
+			Cells.of("4/5", 4, 5),
+			Cells.of("5/5", 5, 5)
+		).stream().collect(toMap(cell -> cell.id(), cell -> cell));
+		
+		return CellGroups.boxBlockOf("5", 9, cells, Cells.of("3/3", 3, 3), 3, 3);
+	}
+
+	@Override
+	public BoxBlock<Object> createNonEqualValue() {
+		Map<String, Cell<Object>> cells = Arrays.asList(
+			Cells.of("3/0", 3, 0),
+			Cells.of("4/0", 4, 0),
+			Cells.of("5/0", 5, 0),
+			Cells.of("3/1", 3, 1),
+			Cells.of("4/1", 4, 1),
+			Cells.of("5/1", 5, 1),
+			Cells.of("3/2", 3, 2),
+			Cells.of("4/2", 4, 2),
+			Cells.of("5/2", 5, 2)
+		).stream().collect(toMap(cell -> cell.id(), cell -> cell));
+		
+		return CellGroups.boxBlockOf("2", 9, cells, Cells.of("3/0", 3, 0), Cells.of("5/2", 5, 2));
+	}
+
+	@Override
+	public BoxBlock<Object> createValue() {
+		Map<String, Cell<Object>> cells = Arrays.asList(
+			Cells.of("3/3", 3, 3),
+			Cells.of("4/3", 4, 3),
+			Cells.of("5/3", 5, 3),
+			Cells.of("3/4", 3, 4),
+			Cells.of("4/4", 4, 4),
+			Cells.of("5/4", 5, 4),
+			Cells.of("3/5", 3, 5),
+			Cells.of("4/5", 4, 5),
+			Cells.of("5/5", 5, 5)
+		).stream().collect(toMap(cell -> cell.id(), cell -> cell));
+		
+		return CellGroups.boxBlockOf("5", 9, cells, Cells.of("3/3", 3, 3), 3, 3);
+	}
+}

--- a/src/test/java/com/kori_47/sudoku/ReferenceColumnImplementationTest.java
+++ b/src/test/java/com/kori_47/sudoku/ReferenceColumnImplementationTest.java
@@ -1,0 +1,202 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+import static java.util.stream.Collectors.toMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This class is used to define and run tests on the reference implementation of {@link Column},
+ * i.e, the {@code Row} instances returned by {@link CellGroups#columnOf(String, int, java.util.Map, int)}
+ * method and it's derivetives.
+ * 
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Wed, 20 May 2020 14:32:36
+ */
+public class ReferenceColumnImplementationTest implements ColumnTest {
+
+	@Override
+	public Column<Object> createSmallerValue() {
+		return CellGroups.columnOf(
+				"1", 9,
+				Arrays.asList(
+					Cells.of("1/0", 1, 0),
+					Cells.of("1/1", 1, 1),
+					Cells.of("1/2", 1, 2),
+					Cells.of("1/3", 1, 3),
+					Cells.of("1/4", 1, 4),
+					Cells.of("1/5", 1, 5),
+					Cells.of("1/6", 1, 6),
+					Cells.of("1/7", 1, 7),
+					Cells.of("1/8", 1, 8)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			1);
+	}
+
+	@Override
+	public Column<Object> createEqualValue() {
+		return CellGroups.columnOf(
+				"2", 9,
+				Arrays.asList(
+					Cells.of("2/0", 2, 0),
+					Cells.of("2/1", 2, 1),
+					Cells.of("2/2", 2, 2),
+					Cells.of("2/3", 2, 3),
+					Cells.of("2/4", 2, 4),
+					Cells.of("2/5", 2, 5),
+					Cells.of("2/6", 2, 6),
+					Cells.of("2/7", 2, 7),
+					Cells.of("2/8", 2, 8)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			2);
+	}
+
+	@Override
+	public Column<Object> createLargerValue() {
+		return CellGroups.columnOf(
+				"3", 9,
+				Arrays.asList(
+					Cells.of("3/0", 3, 0),
+					Cells.of("3/1", 3, 1),
+					Cells.of("3/2", 3, 2),
+					Cells.of("3/3", 3, 3),
+					Cells.of("3/4", 3, 4),
+					Cells.of("3/5", 3, 5),
+					Cells.of("3/6", 3, 6),
+					Cells.of("3/7", 3, 7),
+					Cells.of("3/8", 3, 8)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			3);
+	}
+
+	@Test
+	@Override
+	public void testGetCellUsingCellId() {
+		Column<Object> column = createValue();
+
+		// get some Cell using their id's
+		Optional<Cell<Object>> cell1 = column.getCell("2/1");
+		Optional<Cell<Object>> cell2 = column.getCell("2/2");
+		Optional<Cell<Object>> cell3 = column.getCell("3/1");
+
+		// assert that getting an available or non available Cell using id
+		// returns correct availability results
+		assertTrue(cell1.isPresent());
+		assertTrue(cell2.isPresent());
+		assertFalse(cell3.isPresent());
+
+		// assert that getting a Cell using id returns a valid result
+		assertEquals(cell1.get(), Cells.of("2/1", 2, 1));
+		assertEquals(cell2.get(), Cells.of("2/2", 2, 2));
+	}
+
+	@Test
+	@Override
+	public void testGetCellUsingCellCoordinates() {
+		Column<Object> column = createValue();
+
+		// get some Cell using their coordinates
+		Optional<Cell<Object>> cell1 = column.getCell(2, 1);
+		Optional<Cell<Object>> cell2 = column.getCell(2, 2);
+		Optional<Cell<Object>> cell3 = column.getCell(3, 1);
+
+		// assert that getting an available or non available Cell using coordinates
+		// returns correct availability results
+		assertTrue(cell1.isPresent());
+		assertTrue(cell2.isPresent());
+		assertFalse(cell3.isPresent());
+
+		// assert that getting a Cell using coordinates returns a valid result
+		assertEquals(cell1.get(), Cells.of("2/1", 2, 1));
+		assertEquals(cell2.get(), Cells.of("2/2", 2, 2));
+	}
+
+	@Test
+	@Override
+	public void testStartCell() {
+		Column<Object> column1 = createSmallerValue();
+		Column<Object> column2 = createValue();
+		Column<Object> column3 = createLargerValue();
+		Column<Object> column4 = createNonEqualValue();
+
+		// assert that we have the correct start Cells
+		assertEquals(column1.startCell(), Cells.of("1/0", 1, 0));
+		assertEquals(column2.startCell(), Cells.of("2/0", 2, 0));
+		assertEquals(column3.startCell(), Cells.of("3/0", 3, 0));
+		assertEquals(column4.startCell(), Cells.of("2/0", 2, 0));
+	}
+
+	@Test
+	@Override
+	public void testEndCell() {
+		Column<Object> column1 = createSmallerValue();
+		Column<Object> column2 = createValue();
+		Column<Object> column3 = createLargerValue();
+		Column<Object> column4 = createNonEqualValue();
+
+		// assert that we have the correct end Cells
+		assertEquals(column1.endCell(), Cells.of("1/8", 1, 8));
+		assertEquals(column2.endCell(), Cells.of("2/8", 2, 8));
+		assertEquals(column3.endCell(), Cells.of("3/8", 3, 8));
+		assertEquals(column4.endCell(), Cells.of("2/4", 2, 4));
+	}
+
+	@Override
+	public Column<Object> createAnotherEqualValue() {
+		return CellGroups.columnOf(
+				"2", 9,
+				Arrays.asList(
+					Cells.of("2/0", 2, 0),
+					Cells.of("2/1", 2, 1),
+					Cells.of("2/2", 2, 2),
+					Cells.of("2/3", 2, 3),
+					Cells.of("2/4", 2, 4),
+					Cells.of("2/5", 2, 5),
+					Cells.of("2/6", 2, 6),
+					Cells.of("2/7", 2, 7),
+					Cells.of("2/8", 2, 8)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			2);
+	}
+
+	@Override
+	public Column<Object> createNonEqualValue() {
+		return CellGroups.columnOf(
+				"2", 5,
+				Arrays.asList(
+					Cells.of("2/0", 2, 0),
+					Cells.of("2/1", 2, 1),
+					Cells.of("2/2", 2, 2),
+					Cells.of("2/3", 2, 3),
+					Cells.of("2/4", 2, 4)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			2);
+	}
+
+	@Override
+	public Column<Object> createValue() {
+		return CellGroups.columnOf(
+				"2", 9,
+				Arrays.asList(
+					Cells.of("2/0", 2, 0),
+					Cells.of("2/1", 2, 1),
+					Cells.of("2/2", 2, 2),
+					Cells.of("2/3", 2, 3),
+					Cells.of("2/4", 2, 4),
+					Cells.of("2/5", 2, 5),
+					Cells.of("2/6", 2, 6),
+					Cells.of("2/7", 2, 7),
+					Cells.of("2/8", 2, 8)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			2);
+	}
+}

--- a/src/test/java/com/kori_47/sudoku/ReferenceRowImplementationTest.java
+++ b/src/test/java/com/kori_47/sudoku/ReferenceRowImplementationTest.java
@@ -1,0 +1,202 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+import static java.util.stream.Collectors.toMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This class is used to define and run tests on the reference implementation
+ * of {@link Row}, i.e, the {@code Row} instances returned by
+ * {@link CellGroups#rowOf(String, int, java.util.Map, int)} method and it's derivetives.
+ * 
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Tue, 19 May 2020 14:20:15
+ */
+public class ReferenceRowImplementationTest implements RowTest {
+
+	@Override
+	public Row<Object> createSmallerValue() {
+		return CellGroups.rowOf(
+				"1", 9,
+				Arrays.asList(
+					Cells.of("0/1", 0, 1),
+					Cells.of("1/1", 1, 1),
+					Cells.of("2/1", 2, 1),
+					Cells.of("3/1", 3, 1),
+					Cells.of("4/1", 4, 1),
+					Cells.of("5/1", 5, 1),
+					Cells.of("6/1", 6, 1),
+					Cells.of("7/1", 7, 1),
+					Cells.of("8/1", 8, 1)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			1);
+	}
+
+	@Override
+	public Row<Object> createEqualValue() {
+		return CellGroups.rowOf(
+				"2", 9,
+				Arrays.asList(
+					Cells.of("0/2", 0, 2),
+					Cells.of("1/2", 1, 2),
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/2", 3, 2),
+					Cells.of("4/2", 4, 2),
+					Cells.of("5/2", 5, 2),
+					Cells.of("6/2", 6, 2),
+					Cells.of("7/2", 7, 2),
+					Cells.of("8/2", 8, 2)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			2);
+	}
+
+	@Override
+	public Row<Object> createLargerValue() {
+		return CellGroups.rowOf(
+				"3", 9,
+				Arrays.asList(
+					Cells.of("0/3", 0, 3),
+					Cells.of("1/3", 1, 3),
+					Cells.of("2/3", 2, 3),
+					Cells.of("3/3", 3, 3),
+					Cells.of("4/3", 4, 3),
+					Cells.of("5/3", 5, 3),
+					Cells.of("6/3", 6, 3),
+					Cells.of("7/3", 7, 3),
+					Cells.of("8/3", 8, 3)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			3);
+	}
+
+	@Test
+	@Override
+	public void testGetCellUsingCellId() {
+		Row<Object> row = createValue();
+
+		// get some Cell using their id's
+		Optional<Cell<Object>> cell1 = row.getCell("1/2");
+		Optional<Cell<Object>> cell2 = row.getCell("2/2");
+		Optional<Cell<Object>> cell3 = row.getCell("1/3");
+
+		// assert that getting an available or non available Cell using id
+		// returns correct availability results
+		assertTrue(cell1.isPresent());
+		assertTrue(cell2.isPresent());
+		assertFalse(cell3.isPresent());
+
+		// assert that getting a Cell using id returns a valid result
+		assertEquals(cell1.get(), Cells.of("1/2", 1, 2));
+		assertEquals(cell2.get(), Cells.of("2/2", 2, 2));
+	}
+
+	@Test
+	@Override
+	public void testGetCellUsingCellCoordinates() {
+		Row<Object> row = createValue();
+
+		// get some Cell using their coordinates
+		Optional<Cell<Object>> cell1 = row.getCell(1, 2);
+		Optional<Cell<Object>> cell2 = row.getCell(2, 2);
+		Optional<Cell<Object>> cell3 = row.getCell(1, 3);
+
+		// assert that getting an available or non available Cell using coordinates
+		// returns correct availability results
+		assertTrue(cell1.isPresent());
+		assertTrue(cell2.isPresent());
+		assertFalse(cell3.isPresent());
+
+		// assert that getting a Cell using coordinates returns a valid result
+		assertEquals(cell1.get(), Cells.of("1/2", 1, 2));
+		assertEquals(cell2.get(), Cells.of("2/2", 2, 2));
+	}
+
+	@Test
+	@Override
+	public void testStartCell() {
+		Row<Object> row1 = createSmallerValue();
+		Row<Object> row2 = createValue();
+		Row<Object> row3 = createLargerValue();
+		Row<Object> row4 = createNonEqualValue();
+
+		// assert that we have the correct start Cells
+		assertEquals(row1.startCell(), Cells.of("0/1", 0, 1));
+		assertEquals(row2.startCell(), Cells.of("0/2", 0, 2));
+		assertEquals(row3.startCell(), Cells.of("0/3", 0, 3));
+		assertEquals(row4.startCell(), Cells.of("0/2", 0, 2));
+	}
+
+	@Test
+	@Override
+	public void testEndCell() {
+		Row<Object> row1 = createSmallerValue();
+		Row<Object> row2 = createValue();
+		Row<Object> row3 = createLargerValue();
+		Row<Object> row4 = createNonEqualValue();
+
+		// assert that we have the correct end Cells
+		assertEquals(row1.endCell(), Cells.of("8/1", 8, 1));
+		assertEquals(row2.endCell(), Cells.of("8/2", 8, 2));
+		assertEquals(row3.endCell(), Cells.of("8/3", 8, 3));
+		assertEquals(row4.endCell(), Cells.of("4/2", 4, 2));
+	}
+
+	@Override
+	public Row<Object> createAnotherEqualValue() {
+		return CellGroups.rowOf(
+				"2", 9,
+				Arrays.asList(
+					Cells.of("0/2", 0, 2),
+					Cells.of("1/2", 1, 2),
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/2", 3, 2),
+					Cells.of("4/2", 4, 2),
+					Cells.of("5/2", 5, 2),
+					Cells.of("6/2", 6, 2),
+					Cells.of("7/2", 7, 2),
+					Cells.of("8/2", 8, 2)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			2);
+	}
+
+	@Override
+	public Row<Object> createNonEqualValue() {
+		return CellGroups.rowOf(
+				"2", 5,
+				Arrays.asList(
+					Cells.of("0/2", 0, 2),
+					Cells.of("1/2", 1, 2),
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/2", 3, 2),
+					Cells.of("4/2", 4, 2)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			2);
+	}
+
+	@Override
+	public Row<Object> createValue() {
+		return CellGroups.rowOf(
+				"2", 9,
+				Arrays.asList(
+					Cells.of("0/2", 0, 2),
+					Cells.of("1/2", 1, 2),
+					Cells.of("2/2", 2, 2),
+					Cells.of("3/2", 3, 2),
+					Cells.of("4/2", 4, 2),
+					Cells.of("5/2", 5, 2),
+					Cells.of("6/2", 6, 2),
+					Cells.of("7/2", 7, 2),
+					Cells.of("8/2", 8, 2)
+				).stream().collect(toMap(cell -> cell.id(), cell -> cell)), 
+			2);
+	}
+}

--- a/src/test/java/com/kori_47/sudoku/RowTest.java
+++ b/src/test/java/com/kori_47/sudoku/RowTest.java
@@ -1,0 +1,32 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test interface that implementors of the {@link Row} interface can use to test
+ * and validate their implementations.
+ * 
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Sun, 22 Mar 2020 22:14:52
+ */
+public interface RowTest extends UniqueCellGroupTest<Row<Object>>, InterpolatableCellGroupTest<Row<Object>> {
+	
+	@Test
+	@Override
+	default void testCellGroupAccessors() {
+		UniqueCellGroupTest.super.testCellGroupAccessors();
+		InterpolatableCellGroupTest.super.testCellGroupAccessors();
+
+		Row<Object> row = createValue();
+
+		// assert that the index of this Row is a positive number but less than size
+		assertTrue(row.y() >= 0);
+		assertTrue(row.y() < row.size());
+	}
+}

--- a/src/test/java/com/kori_47/sudoku/SymbolsTest.java
+++ b/src/test/java/com/kori_47/sudoku/SymbolsTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Comparator;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -111,5 +112,32 @@ public class SymbolsTest {
 	 	// assert that an IllegalArgumentException is thrown if upTo > 27
 		assertThrows(IllegalArgumentException.class, () -> Symbols.letterSymbolsUpTo(28));
 		assertThrows(IllegalArgumentException.class, () -> Symbols.letterSymbolsUpTo(200));
+	}
+	
+	/**
+	 * Test {@link Symbols#defaultComparator()} static utility method.
+	 */
+	@Test
+	public void testDefaultComparator() {
+		Comparator<Symbol<?>> comparator = Symbols.defaultComparator();
+		
+		// assert that the Comparator returned isn't null
+		assertNotNull(comparator);
+		
+		// create Cells for testing the Comparator
+		Symbol<Integer> symbol1 = Symbols.of(Integer.valueOf(0), Integer.valueOf(0));
+		Symbol<Integer> symbol2 = Symbols.of(Integer.valueOf(1), Integer.valueOf(1));
+		Symbol<Integer> symbol3 = Symbols.of(Integer.valueOf(2), Integer.valueOf(2));
+		Symbol<Integer> symbol4 = Symbols.of(Integer.valueOf(3), Integer.valueOf(3));
+		Symbol<Integer> symbol5 = Symbols.of(Integer.valueOf(5), Integer.valueOf(5));
+		Symbol<Integer> symbol6 = Symbols.of(Integer.valueOf(5), Integer.valueOf(5));
+		
+		// assert the Comparator returns the correct values
+		assertTrue(comparator.compare(symbol1, symbol2) < 0);
+		assertTrue(comparator.compare(symbol2, symbol1) > 0);
+		assertTrue(comparator.compare(symbol3, symbol2) > 0);
+		assertTrue(comparator.compare(symbol1, symbol4) < 0);
+		assertTrue(comparator.compare(symbol2, symbol2) == 0);
+		assertTrue(comparator.compare(symbol5, symbol6) == 0);
 	}
 }

--- a/src/test/java/com/kori_47/sudoku/UniqueCellGroupTest.java
+++ b/src/test/java/com/kori_47/sudoku/UniqueCellGroupTest.java
@@ -1,0 +1,143 @@
+/**
+ * 
+ */
+package com.kori_47.sudoku;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * This is a test interface that implementors of the {@link UniqueCellGroup} interface can use to test
+ * and validate their implementations.
+ * 
+ * @author <a href="https://github.com/kennedykori">Kennedy Kori</a>
+ *
+ * @since Sun, 22 Mar 2020 21:38:36
+ */
+public interface UniqueCellGroupTest<T extends UniqueCellGroup<Object>> extends CellGroupTest<T> {
+	
+	@Test
+	@Override
+	default void testCellGroupAccessors() {
+		CellGroupTest.super.testCellGroupAccessors();
+		T cellGroup = createValue();
+		T cellGroup1 = createEqualValue();
+		T cellGroup2 = createNonEqualValue();
+		
+		// assert that the returned id isn't null
+		assertNotNull(cellGroup.id());
+		assertNotNull(cellGroup1.id());
+		assertNotNull(cellGroup2.id());
+	}
+
+	/**
+	 * Returns a smaller value of the {@code Testable} entity. That is, returns
+	 * a value smaller than the value returned by the {@link #createValue()}
+	 * method.
+	 * 
+	 * @return a smaller value of the {@code Testable} entity.
+	 */
+	T createSmallerValue();
+	
+	/**
+	 * Returns an equal instance of the {@code Testable} entity. That is, returns
+	 * a value equal to the value returned by the {@link #createValue()} method.
+	 * 
+	 * @return an equal instance of the {@code Testable} entity.
+	 */
+	T createEqualValue();
+	
+	/**
+	 * Returns a larger value of the {@code Testable} entity. That is, returns
+	 * a value larger than the value returned by the {@link #createValue()}
+	 * method.
+	 * 
+	 * @return a larger value of the {@code Testable} entity.
+	 */
+	T createLargerValue();
+	
+	/**
+	 * Tests that a {@code 0} is returned when comparing two equal values.
+	 */
+	@Test
+	default void testReturnsZeroWhenComparingEqualValues() {
+		T value = createValue();
+		T equalValue = createEqualValue();
+		
+		assertEquals(0, equalValue.compareTo(value));
+		assertEquals(0, value.compareTo(equalValue));
+		assertEquals(0, value.compareTo(value));
+	}
+
+	/**
+	 * Tests that a positive {@code Integer} is returned when comparing larger values to
+	 * smaller values.
+	 */
+	@Test
+	default void testReturnsPositiveIntegerWhenComparingToSmallerValues() {
+		T value = createValue();
+		T smallerValue = createSmallerValue();
+		T largerValue = createLargerValue();
+		
+		assertTrue(value.compareTo(smallerValue) > 0);
+		assertTrue(largerValue.compareTo(value) > 0);
+		assertTrue(largerValue.compareTo(smallerValue) > 0);
+	}
+	
+	/**
+	 * Tests that a negative {@code Integer} is returned when comparing smaller values to
+	 * larger values.
+	 */
+	@Test
+	default void testReturnsNegativeIntegerWhenComparingToLargerValues() {
+		T value = createValue();
+		T smallerValue = createSmallerValue();
+		T largerValue = createLargerValue();
+		
+		assertTrue(smallerValue.compareTo(value) < 0);
+		assertTrue(value.compareTo(largerValue) < 0);
+		assertTrue(smallerValue.compareTo(largerValue) < 0);
+	}
+	
+	/**
+	 * Test that for any non-null {@code Testable} values {@code x}, {@code y} and {@code z},
+	 * if {@code x.compareTo(y)>0 && y.compareTo(z)>0}, then {@code x.compareTo(z)>0}.
+	 */
+	@Test
+	default void testForTransitivityDuringComparisions() {
+		T value = createValue();
+		T smallerValue = createSmallerValue();
+		T largerValue = createLargerValue();
+		
+		assertTrue(largerValue.compareTo(value) > 0
+				&& value.compareTo(smallerValue) > 0
+				&& largerValue.compareTo(smallerValue) > 0);
+		assertTrue(smallerValue.compareTo(value) < 0
+				&& value.compareTo(largerValue) < 0
+				&& smallerValue.compareTo(largerValue) < 0);
+	}
+	
+	/**
+	 * Test that for any non-null {@code Testable} values {@code x}, {@code y} and {@code z},
+	 * {@code x.compareTo(y)==0} implies that {@code sgn(x.compareTo(z)) == sgn(y.compareTo(z))}
+	 * for all {@code z}.
+	 */
+	@Test
+	default void testForConsistencyDuringComparisions() {
+		T value = createValue();
+		T equalValue = createEqualValue();
+		T smallerValue = createSmallerValue();
+		T largerValue = createLargerValue();
+		
+		assertTrue(value.compareTo(equalValue) == 0
+				&& value.compareTo(smallerValue) > 0
+				&& equalValue.compareTo(smallerValue) > 0);
+		
+		assertTrue(value.compareTo(equalValue) == 0
+				&& value.compareTo(largerValue) < 0
+				&& equalValue.compareTo(largerValue) < 0);
+	}
+}


### PR DESCRIPTION
Add initial tests and refactor as necessary to make sure the tests pass.

Add the following tests:

- Tests for the `Symbols` utility class
- Tests for `Cells` utility class
- Add `CellGroups` test interfaces
- Add `Row` implementations test interface
- `Comparator` tests on `UniqueCellGroupTest`

   This is because we need to test the comparison characteristics of a
   `UniqueCellGroup` but since we are unable to extend the
   `ComparableTest` we add those tests directly to this interface.

- Tests for the `InterpolatableCellGroups` class.
- Tests for the `Block` class.
- Tests for the `Column` class.
- Tests for the `BoxBlock` class.
- Tests for the reference `Row` implementation.
- Tests for the reference `Column` implementation.
- Tests for the `InterpolatableCellGroups` class.
- Tests for the reference `BoxBlock` implementation.
- Tests for `CellGroups.rowOf`, `CellGroups.columnOf`, and `CellGroups.boxBlockOf` factory methods.

Included are also the following minor improvements and fixes:

- Add the `deepEquals` utility method in the `Cells` utility class.
- Rename the `swapCellPropeties` method to `swapCellSymbols` on the `Cells` class.
- Minor fix `Cells` utility class.
- Minor Javadoc fixes on the `UniqueCellGroup` test interface.
- Refactor `RowTest` by extending `InterpolatableCellGroupTest`.
- Refactor `BlockTest` to be generic.
- Limit the number of the final cells map to the size of `CellGroup`.
- Refactor reference `Row` and `Column` to accept valid cells only.
- Remove erroneous tests.
- Minor API fixes and Javadoc additions and clarifications.
- Add more clarifications of the name **Interpolatable**.
- Add a new invariant on `CellGroups.boxBlockOf`.

   The new invariant will ensure that the `BoxBlocks` instances returned by
   that factory method are valid by ensuring the product of the calculated
   `blockColumns` and `blockRows` are equal to the sizes of the new `BoxBlock`
   instances.